### PR TITLE
Lightweight styling

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -35,7 +35,7 @@ TextBox,
 // BlankUserControl,
 ClickMode,
 MenuFlyout,
-} from 'react-native-xaml'; // Would be from 'react-native-xaml' outside of this repo;
+} from 'react-native-xaml';
 
 const Section = ({children, title}): Node => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -85,9 +85,16 @@ const App: () => Node = () => {
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
           }}>
               {/* <BlankUserControl  onHappened={(arg) => alert(JSON.stringify(arg.nativeEvent)) } /> */}
-                  <Button content={{ string: `Last selected option = ${option} ${count}` }} foreground="red"
-                      onClick={(a) => { alert(JSON.stringify(a.nativeEvent)); setCount(count + 1); setIsOpen(true); }}
+                  <Button content={{ string: `Last selected option = ${option} ${count}` }}
+                      onClick={(a) => { 
+                        alert(JSON.stringify(a.nativeEvent)); 
+                        setCount(count + 1); 
+                        setIsOpen(true); }}
                       clickMode={ClickMode.Release}
+                      resources={{ 
+                        ButtonForeground: "#00fff1",
+                        ButtonForegroundPressed: "#2090ff",
+                     }}
                       />
                   {/*<StackPanel orientation="horizontal">*/}
                   {/*    <HyperlinkButton content={{ string: "Click me!" }} onClick={(args) => {*/}

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="ReactNativeModule.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Serialize.h" />
+    <ClInclude Include="Styling.h" />
     <ClInclude Include="XamlMetadata.h" />
     <ClInclude Include="XamlViewManager.h" />
   </ItemGroup>
@@ -153,6 +154,7 @@
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="Serialize.cpp" />
+    <ClCompile Include="Styling.cpp" />
     <ClCompile Include="XamlMetadata.cpp" />
     <ClCompile Include="XamlViewManager.cpp" />
   </ItemGroup>

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj.filters
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj.filters
@@ -13,6 +13,7 @@
       <Filter>Codegen</Filter>
     </ClCompile>
     <ClCompile Include="Serialize.cpp" />
+    <ClCompile Include="Styling.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -28,6 +29,7 @@
       <Filter>Codegen</Filter>
     </ClInclude>
     <ClInclude Include="Serialize.h" />
+    <ClInclude Include="Styling.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="PropertySheet.props" />

--- a/package/windows/ReactNativeXaml/Styling.cpp
+++ b/package/windows/ReactNativeXaml/Styling.cpp
@@ -1,0 +1,128 @@
+#include <pch.h>
+#include "Styling.h"
+
+/// from RNW ValueUtils.cpp
+#pragma region Copied from RNW ValueUtils.cpp
+namespace ColorUtils {
+  struct ColorComp {
+    bool operator()(const winrt::Windows::UI::Color& lhs, const winrt::Windows::UI::Color& rhs) const {
+      return (
+        lhs.A < rhs.A ||
+        lhs.A == rhs.A && (lhs.R < rhs.R || lhs.R == rhs.R && (lhs.G < rhs.G || lhs.G == rhs.G && lhs.B < rhs.B)));
+    }
+  };
+
+  xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color) {
+    thread_local static std::map<winrt::Windows::UI::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp>
+      solidColorBrushCache;
+
+    if (solidColorBrushCache.count(color) != 0) {
+      if (auto brush = solidColorBrushCache[color].get()) {
+        return brush;
+      }
+    }
+
+    xaml::Media::SolidColorBrush brush(color);
+    solidColorBrushCache[color] = winrt::make_weak(brush);
+    return brush;
+  }
+
+  inline BYTE GetAFromArgb(DWORD v) {
+    return ((BYTE)((v & 0xFF000000) >> 24));
+  }
+  inline BYTE GetRFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x00FF0000) >> 16));
+  }
+  inline BYTE GetGFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x0000FF00) >> 8));
+  }
+  inline BYTE GetBFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x000000FF)));
+  }
+
+
+  winrt::Windows::UI::Color ColorFromNumber(DWORD argb) {
+    return winrt::ColorHelper::FromArgb(GetAFromArgb(argb), GetRFromArgb(argb), GetGFromArgb(argb), GetBFromArgb(argb));
+  }
+
+  winrt::Windows::UI::Color ColorFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
+    if (v.Type() != winrt::Microsoft::ReactNative::JSValueType::Int64 &&
+      v.Type() != winrt::Microsoft::ReactNative::JSValueType::Double)
+      return winrt::Windows::UI::Colors::Transparent();
+    return ColorFromNumber(v.AsUInt32());
+  }
+
+  xaml::Media::Brush GetBrushFromThemeResource(winrt::hstring resourceName) {
+    winrt::hstring xamlString =
+      L"<ResourceDictionary"
+      L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
+      L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+      L"  <SolidColorBrush"
+      L"      x:Key='" +
+      resourceName +
+      L"'"
+      L"      Color='{ThemeResource " +
+      resourceName +
+      "}' />"
+      L"</ResourceDictionary>";
+
+    auto dictionary{ winrt::unbox_value<xaml::ResourceDictionary>(xaml::Markup::XamlReader::Load(xamlString)) };
+
+    auto brush{ winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.TryLookup(winrt::box_value(resourceName))) };
+    return brush;
+  }
+
+  xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
+    thread_local static std::map<winrt::hstring, winrt::weak_ref<xaml::Media::Brush>> accentColorMap = {
+        {L"SystemAccentColor", {nullptr}},
+        {L"SystemAccentColorLight1", {nullptr}},
+        {L"SystemAccentColorLight2", {nullptr}},
+        {L"SystemAccentColorLight3", {nullptr}},
+        {L"SystemAccentColorDark1", {nullptr}},
+        {L"SystemAccentColorDark2", {nullptr}},
+        {L"SystemAccentColorDark3", {nullptr}},
+        {L"SystemListAccentLowColor", {nullptr}},
+        {L"SystemListAccentMediumColor", {nullptr}},
+        {L"SystemListAccentHighColor", {nullptr}} };
+    xaml::Media::Brush brush{ nullptr };
+
+    if (accentColorMap.find(resourceName) != accentColorMap.end()) {
+      if (brush = accentColorMap.at(resourceName).get()) {
+        return brush;
+      }
+      try {
+        brush = GetBrushFromThemeResource(resourceName);
+      }
+      catch (...) {}
+    }
+
+    if (!brush) {
+      try {
+        auto color = winrt::unbox_value<winrt::Windows::UI::Color>(xaml::Markup::XamlBindingHelper::ConvertValue(winrt::xaml_typename<winrt::Windows::UI::Color>(), winrt::box_value(resourceName)));
+        brush = SolidBrushFromColor(color);
+      }
+      catch (...) {}
+    }
+    if (!brush) {
+      winrt::IInspectable resource{ xaml::Application::Current().Resources().TryLookup(winrt::box_value(resourceName)) };
+      brush = winrt::unbox_value<xaml::Media::Brush>(resource);
+    }
+
+    if (brush) {
+      accentColorMap[resourceName] = winrt::make_weak(brush);
+    }
+
+    return brush;
+  }
+
+
+
+  xaml::Media::Brush BrushFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
+    if (v.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+      return BrushFromColorObject(winrt::to_hstring(v.AsString()));
+    }
+
+    return SolidBrushFromColor(ColorFrom(v));
+  }
+}
+#pragma endregion

--- a/package/windows/ReactNativeXaml/Styling.h
+++ b/package/windows/ReactNativeXaml/Styling.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <JSValue.h>
+
+namespace ColorUtils {
+  xaml::Media::Brush BrushFrom(const winrt::Microsoft::ReactNative::JSValue& v);
+}

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -6,131 +6,7 @@
 #include "XamlMetadata.h"
 #include <winrt/Windows.UI.Xaml.Core.Direct.h>
 #include <UI.Xaml.Input.h>
-
-/// from RNW ValueUtils.cpp
-#pragma region Copied from RNW ValueUtils.cpp
-namespace ColorUtils {
-  struct ColorComp {
-    bool operator()(const winrt::Windows::UI::Color& lhs, const winrt::Windows::UI::Color& rhs) const {
-      return (
-        lhs.A < rhs.A ||
-        lhs.A == rhs.A && (lhs.R < rhs.R || lhs.R == rhs.R && (lhs.G < rhs.G || lhs.G == rhs.G && lhs.B < rhs.B)));
-    }
-  };
-
-  xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color) {
-    thread_local static std::map<winrt::Windows::UI::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp>
-      solidColorBrushCache;
-
-    if (solidColorBrushCache.count(color) != 0) {
-      if (auto brush = solidColorBrushCache[color].get()) {
-        return brush;
-      }
-    }
-
-    xaml::Media::SolidColorBrush brush(color);
-    solidColorBrushCache[color] = winrt::make_weak(brush);
-    return brush;
-  }
-
-  inline BYTE GetAFromArgb(DWORD v) {
-    return ((BYTE)((v & 0xFF000000) >> 24));
-  }
-  inline BYTE GetRFromArgb(DWORD v) {
-    return ((BYTE)((v & 0x00FF0000) >> 16));
-  }
-  inline BYTE GetGFromArgb(DWORD v) {
-    return ((BYTE)((v & 0x0000FF00) >> 8));
-  }
-  inline BYTE GetBFromArgb(DWORD v) {
-    return ((BYTE)((v & 0x000000FF)));
-  }
-
-
-  winrt::Windows::UI::Color ColorFromNumber(DWORD argb) {
-    return winrt::ColorHelper::FromArgb(GetAFromArgb(argb), GetRFromArgb(argb), GetGFromArgb(argb), GetBFromArgb(argb));
-  }
-
-  winrt::Windows::UI::Color ColorFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
-    if (v.Type() != winrt::Microsoft::ReactNative::JSValueType::Int64 &&
-      v.Type() != winrt::Microsoft::ReactNative::JSValueType::Double)
-      return winrt::Windows::UI::Colors::Transparent();
-    return ColorFromNumber(v.AsUInt32());
-  }
-
-  xaml::Media::Brush GetBrushFromThemeResource(winrt::hstring resourceName) {
-    winrt::hstring xamlString =
-      L"<ResourceDictionary"
-      L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
-      L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
-      L"  <SolidColorBrush"
-      L"      x:Key='" +
-      resourceName +
-      L"'"
-      L"      Color='{ThemeResource " +
-      resourceName +
-      "}' />"
-      L"</ResourceDictionary>";
-
-    auto dictionary{ winrt::unbox_value<xaml::ResourceDictionary>(xaml::Markup::XamlReader::Load(xamlString)) };
-
-    auto brush{ winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.TryLookup(winrt::box_value(resourceName))) };
-    return brush;
-  }
-
-  xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
-    thread_local static std::map<winrt::hstring, winrt::weak_ref<xaml::Media::Brush>> accentColorMap = {
-        {L"SystemAccentColor", {nullptr}},
-        {L"SystemAccentColorLight1", {nullptr}},
-        {L"SystemAccentColorLight2", {nullptr}},
-        {L"SystemAccentColorLight3", {nullptr}},
-        {L"SystemAccentColorDark1", {nullptr}},
-        {L"SystemAccentColorDark2", {nullptr}},
-        {L"SystemAccentColorDark3", {nullptr}},
-        {L"SystemListAccentLowColor", {nullptr}},
-        {L"SystemListAccentMediumColor", {nullptr}},
-        {L"SystemListAccentHighColor", {nullptr}} };
-    xaml::Media::Brush brush{ nullptr };
-
-    if (accentColorMap.find(resourceName) != accentColorMap.end()) {
-      if (brush = accentColorMap.at(resourceName).get()) {
-        return brush;
-      }
-      try {
-        brush = GetBrushFromThemeResource(resourceName);
-      } catch (...) {}
-    }
-
-    if (!brush) {
-      try {
-        auto color = winrt::unbox_value<winrt::Windows::UI::Color>(xaml::Markup::XamlBindingHelper::ConvertValue(winrt::xaml_typename<winrt::Windows::UI::Color>(), winrt::box_value(resourceName)));
-        brush = SolidBrushFromColor(color);
-      }
-      catch (...) {}
-    }
-    if (!brush) {
-      winrt::IInspectable resource{ xaml::Application::Current().Resources().TryLookup(winrt::box_value(resourceName)) };
-      brush = winrt::unbox_value<xaml::Media::Brush>(resource);
-    }
-
-    if (brush) {
-      accentColorMap[resourceName] = winrt::make_weak(brush);
-    }
-
-    return brush;
-  }
-
-
-
-  xaml::Media::Brush BrushFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
-    if (v.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-      return BrushFromColorObject(winrt::to_hstring(v.AsString()));
-    }
-
-    return SolidBrushFromColor(ColorFrom(v));
-  }
-}
-#pragma endregion
+#include "Styling.h"
 
 using namespace winrt;
 using namespace Microsoft::ReactNative;
@@ -164,24 +40,20 @@ namespace winrt::ReactNativeXaml {
       auto brush = ColorUtils::BrushFrom(value);
       auto nameII = winrt::box_value(winrt::to_hstring(name));
       rd.Insert(nameII, brush);
-      //if (auto v = rd.TryLookup(nameII)) {
-      //  if (auto scb = v.try_as<xaml::Media::SolidColorBrush>()) {
-      //    if (auto newScb = brush.try_as<xaml::Media::SolidColorBrush>()) {
-      //      scb.Color(newScb.Color());
-      //      continue;
-      //    }
-      //    else {
-      //      assert(false && "changing from a color to a non-color brush");
-      //    }
-      //  }
-      //  else {
-      //    assert(false && "changing from a non-color brush");
-      //  }
-      //}
-      ////else 
-      //{
-      //  rd.Insert(nameII, brush);
-      //}
+      if (auto v = rd.TryLookup(nameII)) {
+        if (auto scb = v.try_as<xaml::Media::SolidColorBrush>()) {
+          if (auto newScb = brush.try_as<xaml::Media::SolidColorBrush>()) {
+            scb.Color(newScb.Color());
+            continue;
+          }
+          else {
+            assert(false && "changing from a color to a non-color brush");
+          }
+        }
+        else {
+          assert(false && "changing from a non-color brush");
+        }
+      }
     }
     fe.Resources(rd);
   }

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -6,6 +6,132 @@
 #include "XamlMetadata.h"
 #include <winrt/Windows.UI.Xaml.Core.Direct.h>
 #include <UI.Xaml.Input.h>
+
+/// from RNW ValueUtils.cpp
+#pragma region Copied from RNW ValueUtils.cpp
+namespace ColorUtils {
+  struct ColorComp {
+    bool operator()(const winrt::Windows::UI::Color& lhs, const winrt::Windows::UI::Color& rhs) const {
+      return (
+        lhs.A < rhs.A ||
+        lhs.A == rhs.A && (lhs.R < rhs.R || lhs.R == rhs.R && (lhs.G < rhs.G || lhs.G == rhs.G && lhs.B < rhs.B)));
+    }
+  };
+
+  xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color) {
+    thread_local static std::map<winrt::Windows::UI::Color, winrt::weak_ref<xaml::Media::SolidColorBrush>, ColorComp>
+      solidColorBrushCache;
+
+    if (solidColorBrushCache.count(color) != 0) {
+      if (auto brush = solidColorBrushCache[color].get()) {
+        return brush;
+      }
+    }
+
+    xaml::Media::SolidColorBrush brush(color);
+    solidColorBrushCache[color] = winrt::make_weak(brush);
+    return brush;
+  }
+
+  inline BYTE GetAFromArgb(DWORD v) {
+    return ((BYTE)((v & 0xFF000000) >> 24));
+  }
+  inline BYTE GetRFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x00FF0000) >> 16));
+  }
+  inline BYTE GetGFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x0000FF00) >> 8));
+  }
+  inline BYTE GetBFromArgb(DWORD v) {
+    return ((BYTE)((v & 0x000000FF)));
+  }
+
+
+  winrt::Windows::UI::Color ColorFromNumber(DWORD argb) {
+    return winrt::ColorHelper::FromArgb(GetAFromArgb(argb), GetRFromArgb(argb), GetGFromArgb(argb), GetBFromArgb(argb));
+  }
+
+  winrt::Windows::UI::Color ColorFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
+    if (v.Type() != winrt::Microsoft::ReactNative::JSValueType::Int64 &&
+      v.Type() != winrt::Microsoft::ReactNative::JSValueType::Double)
+      return winrt::Windows::UI::Colors::Transparent();
+    return ColorFromNumber(v.AsUInt32());
+  }
+
+  xaml::Media::Brush GetBrushFromThemeResource(winrt::hstring resourceName) {
+    winrt::hstring xamlString =
+      L"<ResourceDictionary"
+      L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
+      L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+      L"  <SolidColorBrush"
+      L"      x:Key='" +
+      resourceName +
+      L"'"
+      L"      Color='{ThemeResource " +
+      resourceName +
+      "}' />"
+      L"</ResourceDictionary>";
+
+    auto dictionary{ winrt::unbox_value<xaml::ResourceDictionary>(xaml::Markup::XamlReader::Load(xamlString)) };
+
+    auto brush{ winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.TryLookup(winrt::box_value(resourceName))) };
+    return brush;
+  }
+
+  xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
+    thread_local static std::map<winrt::hstring, winrt::weak_ref<xaml::Media::Brush>> accentColorMap = {
+        {L"SystemAccentColor", {nullptr}},
+        {L"SystemAccentColorLight1", {nullptr}},
+        {L"SystemAccentColorLight2", {nullptr}},
+        {L"SystemAccentColorLight3", {nullptr}},
+        {L"SystemAccentColorDark1", {nullptr}},
+        {L"SystemAccentColorDark2", {nullptr}},
+        {L"SystemAccentColorDark3", {nullptr}},
+        {L"SystemListAccentLowColor", {nullptr}},
+        {L"SystemListAccentMediumColor", {nullptr}},
+        {L"SystemListAccentHighColor", {nullptr}} };
+    xaml::Media::Brush brush{ nullptr };
+
+    if (accentColorMap.find(resourceName) != accentColorMap.end()) {
+      if (brush = accentColorMap.at(resourceName).get()) {
+        return brush;
+      }
+      try {
+        brush = GetBrushFromThemeResource(resourceName);
+      } catch (...) {}
+    }
+
+    if (!brush) {
+      try {
+        auto color = winrt::unbox_value<winrt::Windows::UI::Color>(xaml::Markup::XamlBindingHelper::ConvertValue(winrt::xaml_typename<winrt::Windows::UI::Color>(), winrt::box_value(resourceName)));
+        brush = SolidBrushFromColor(color);
+      }
+      catch (...) {}
+    }
+    if (!brush) {
+      winrt::IInspectable resource{ xaml::Application::Current().Resources().TryLookup(winrt::box_value(resourceName)) };
+      brush = winrt::unbox_value<xaml::Media::Brush>(resource);
+    }
+
+    if (brush) {
+      accentColorMap[resourceName] = winrt::make_weak(brush);
+    }
+
+    return brush;
+  }
+
+
+
+  xaml::Media::Brush BrushFrom(const winrt::Microsoft::ReactNative::JSValue& v) {
+    if (v.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+      return BrushFromColorObject(winrt::to_hstring(v.AsString()));
+    }
+
+    return SolidBrushFromColor(ColorFrom(v));
+  }
+}
+#pragma endregion
+
 using namespace winrt;
 using namespace Microsoft::ReactNative;
 using namespace xaml;
@@ -29,10 +155,42 @@ namespace winrt::ReactNativeXaml {
     return xamlMetadata.Create(typeName, m_reactContext);
   }
 
+  void SetResources(const xaml::FrameworkElement& fe, const JSValueObject& dict) {
+    ResourceDictionary rd;
+
+    for (auto const& entry : dict) {
+      const auto& name = entry.first;
+      const auto& value = entry.second;
+      auto brush = ColorUtils::BrushFrom(value);
+      auto nameII = winrt::box_value(winrt::to_hstring(name));
+      rd.Insert(nameII, brush);
+      //if (auto v = rd.TryLookup(nameII)) {
+      //  if (auto scb = v.try_as<xaml::Media::SolidColorBrush>()) {
+      //    if (auto newScb = brush.try_as<xaml::Media::SolidColorBrush>()) {
+      //      scb.Color(newScb.Color());
+      //      continue;
+      //    }
+      //    else {
+      //      assert(false && "changing from a color to a non-color brush");
+      //    }
+      //  }
+      //  else {
+      //    assert(false && "changing from a non-color brush");
+      //  }
+      //}
+      ////else 
+      //{
+      //  rd.Insert(nameII, brush);
+      //}
+    }
+    fe.Resources(rd);
+  }
+
   // IViewManagerWithNativeProperties
   IMapView<hstring, ViewManagerPropertyType> XamlViewManager::NativeProps() noexcept {
     auto nativeProps = winrt::single_threaded_map<hstring, ViewManagerPropertyType>();
     nativeProps.Insert(L"type", ViewManagerPropertyType::String);
+    nativeProps.Insert(L"resources", ViewManagerPropertyType::Map);
     xamlMetadata.PopulateNativeProps(nativeProps);
     xamlMetadata.PopulateNativeEvents(nativeProps);
     return nativeProps.GetView();
@@ -59,6 +217,9 @@ namespace winrt::ReactNativeXaml {
         else if (auto eventAttacher = xamlMetadata.AttachEvent(m_reactContext, propertyName, control, propertyValue.AsBoolean())) {
         }
         else if (propertyName == "type") {}
+        else if (propertyName == "resources" && propertyValue.Type() == JSValueType::Object && control.try_as<xaml::FrameworkElement>()) {
+          SetResources(control.as<xaml::FrameworkElement>(), propertyValue.AsObject());
+        }
         else {
           auto className = winrt::get_class_name(e);
           assert(false && "unknown property");


### PR DESCRIPTION
This enables using lightweight styling from react-native-xaml via a new object-typed property "resources".
Updates to this property won't work since in UWP XAML, ResourceDictionary is a static resource and does not reevaluate an element's children when a member of the dictionary gets updated. Tracked by https://github.com/microsoft/microsoft-ui-xaml/issues/4443

Fixes #21 