### PR TITLE
Use separate type for the non-FE wrapper

### DIFF
--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj
@@ -157,6 +157,10 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="Serialize.h" />
     <ClInclude Include="Styling.h" />
+    <ClInclude Include="Wrapper.h">
+      <DependentUpon>Wrapper.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="XamlMetadata.h" />
     <ClInclude Include="XamlObject.h" />
     <ClInclude Include="XamlViewManager.h" />
@@ -172,12 +176,19 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="Serialize.cpp" />
     <ClCompile Include="Styling.cpp" />
+    <ClCompile Include="Wrapper.cpp">
+      <DependentUpon>Wrapper.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="XamlMetadata.cpp" />
     <ClCompile Include="XamlObject.cpp" />
     <ClCompile Include="XamlViewManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="Wrapper.idl">
+      <SubType>Designer</SubType>
+    </Midl>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\README.md" />

--- a/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj.filters
+++ b/package/windows/ReactNativeXaml/ReactNativeXaml.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="Wrapper.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/package/windows/ReactNativeXaml/Wrapper.cpp
+++ b/package/windows/ReactNativeXaml/Wrapper.cpp
@@ -1,0 +1,18 @@
+﻿#include "pch.h"
+#include "Wrapper.h"
+#if __has_include("Wrapper.g.cpp")
+#include "Wrapper.g.cpp"
+#endif
+
+namespace winrt::ReactNativeXaml::implementation
+{
+    IInspectable Wrapper::WrappedObject()
+    {
+      return m_value;
+    }
+
+    void Wrapper::WrappedObject(IInspectable value)
+    {
+      m_value = value;
+    }
+}

--- a/package/windows/ReactNativeXaml/Wrapper.h
+++ b/package/windows/ReactNativeXaml/Wrapper.h
@@ -1,0 +1,24 @@
+﻿#pragma once
+
+#include "Wrapper.g.h"
+
+namespace winrt::ReactNativeXaml::implementation
+{
+    struct Wrapper : WrapperT<Wrapper>
+    {
+        Wrapper() = default;
+
+        IInspectable WrappedObject();
+        void WrappedObject(IInspectable value);
+
+    private:
+      IInspectable m_value{nullptr};
+    };
+}
+
+namespace winrt::ReactNativeXaml::factory_implementation
+{
+    struct Wrapper : WrapperT<Wrapper, implementation::Wrapper>
+    {
+    };
+}

--- a/package/windows/ReactNativeXaml/Wrapper.idl
+++ b/package/windows/ReactNativeXaml/Wrapper.idl
@@ -1,0 +1,12 @@
+#include <NamespaceRedirect.h>
+
+namespace ReactNativeXaml
+{
+    [bindable]
+    [default_interface]
+    runtimeclass Wrapper : XAML_NAMESPACE.FrameworkElement
+    {
+        Wrapper();
+        IInspectable WrappedObject;
+    }
+}

--- a/package/windows/ReactNativeXaml/Wrapper.idl
+++ b/package/windows/ReactNativeXaml/Wrapper.idl
@@ -2,7 +2,6 @@
 
 namespace ReactNativeXaml
 {
-    [bindable]
     [default_interface]
     runtimeclass Wrapper : XAML_NAMESPACE.FrameworkElement
     {

--- a/package/windows/ReactNativeXaml/XamlMetadata.cpp
+++ b/package/windows/ReactNativeXaml/XamlMetadata.cpp
@@ -50,9 +50,9 @@ FrameworkElement Wrap(const winrt::Windows::Foundation::IInspectable& d) {
     return fe;
   }
   else {
-    Wrapper cc;
-    cc.Content(d);
-    return cc;
+    winrt::ReactNativeXaml::Wrapper wrapper;
+    wrapper.WrappedObject(d);
+    return wrapper;
   }
 }
 
@@ -82,7 +82,7 @@ void SetIsOpen_FlyoutBase(const xaml::DependencyObject& o, const xaml::Dependenc
 
       // Go from the wrapping ContentControl to the flyout's parent. 
       // We can't use Parent() since we unparent the CC once we add the flyout to the tree
-      if (!target) target = o.as<Wrapper>().DataContext().as<FrameworkElement>();
+      if (!target) target = o.as<winrt::ReactNativeXaml::Wrapper>().DataContext().as<FrameworkElement>();
       auto cn = winrt::get_class_name(target);
       flyout.ShowAt(target);
     }

--- a/package/windows/ReactNativeXaml/XamlMetadata.cpp
+++ b/package/windows/ReactNativeXaml/XamlMetadata.cpp
@@ -19,6 +19,7 @@
 
 #include "Styling.h"
 
+
 namespace jsi = facebook::jsi;
 
 using namespace winrt::Microsoft::ReactNative;
@@ -50,8 +51,9 @@ FrameworkElement Wrap(const winrt::Windows::Foundation::IInspectable& d) {
     return fe;
   }
   else {
-    winrt::ReactNativeXaml::Wrapper wrapper;
+    winrt::ReactNativeXaml::Wrapper wrapper{};
     wrapper.WrappedObject(d);
+
     return wrapper;
   }
 }
@@ -73,6 +75,10 @@ winrt::Windows::Foundation::IInspectable XamlMetadata::Create(const std::string&
   return e;
 }
 
+FrameworkElement GetDataContext_Flyout(winrt::Windows::Foundation::IInspectable wrapper) {
+  return wrapper.as<winrt::ReactNativeXaml::Wrapper>().DataContext().as<xaml::FrameworkElement>();
+}
+
 // FlyoutBase.IsOpen is read-only but we need a way to call ShowAt/Hide, so this hooks it up
 void SetIsOpen_FlyoutBase(const xaml::DependencyObject& o, const xaml::DependencyProperty&, const winrt::Microsoft::ReactNative::JSValue& v, const winrt::Microsoft::ReactNative::IReactContext&) {
   auto flyout = o.try_as<Controls::Primitives::FlyoutBase>();
@@ -82,7 +88,7 @@ void SetIsOpen_FlyoutBase(const xaml::DependencyObject& o, const xaml::Dependenc
 
       // Go from the wrapping ContentControl to the flyout's parent. 
       // We can't use Parent() since we unparent the CC once we add the flyout to the tree
-      if (!target) target = o.as<winrt::ReactNativeXaml::Wrapper>().DataContext().as<FrameworkElement>();
+      if (!target) target = GetDataContext_Flyout(o);
       auto cn = winrt::get_class_name(target);
       flyout.ShowAt(target);
     }

--- a/package/windows/ReactNativeXaml/XamlMetadata.h
+++ b/package/windows/ReactNativeXaml/XamlMetadata.h
@@ -197,8 +197,8 @@ struct PropInfo {
 
 template<typename T>
 T Unwrap(const winrt::Windows::Foundation::IInspectable& i) {
-  if (auto contentControl = i.try_as<winrt::ReactNativeXaml::Wrapper>()) {
-    return contentControl.WrappedObject().try_as<T>();
+  if (auto wrapper = i.try_as<winrt::ReactNativeXaml::Wrapper>()) {
+    return wrapper.WrappedObject().try_as<T>();
   }
   return nullptr;
 }

--- a/package/windows/ReactNativeXaml/XamlMetadata.h
+++ b/package/windows/ReactNativeXaml/XamlMetadata.h
@@ -13,6 +13,8 @@
 #include "Crc32Str.h"
 #include <JSI/JsiApiContext.h>
 #include "XamlObject.h"
+#include <Wrapper.h>
+
 
 using namespace xaml;
 using namespace xaml::Controls;
@@ -94,9 +96,6 @@ namespace winrt::Microsoft::ReactNative {
     value = Uri{ winrt::to_hstring(jsValue.AsString()) };
   }
 }
-
-
-using Wrapper = winrt::Windows::UI::Xaml::Controls::ContentControl;
 
 enum class XamlPropType {
   Boolean,
@@ -198,8 +197,8 @@ struct PropInfo {
 
 template<typename T>
 T Unwrap(const winrt::Windows::Foundation::IInspectable& i) {
-  if (auto contentControl = i.try_as<Wrapper>()) {
-    return contentControl.Content().try_as<T>();
+  if (auto contentControl = i.try_as<winrt::ReactNativeXaml::Wrapper>()) {
+    return contentControl.WrappedObject().try_as<T>();
   }
   return nullptr;
 }

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -138,7 +138,8 @@ namespace winrt::ReactNativeXaml {
     else if (auto wrappedChild = child.try_as<Wrapper>()) {
       if (auto childContent = wrappedChild.WrappedObject()) {
         childType = winrt::get_class_name(childContent);
-        auto tag = wrappedChild.Tag();
+        auto childFE = child.as<FrameworkElement>();
+        auto tag = childFE.Tag();
         if (auto depObj = childContent.try_as<DependencyObject>()) {
           // tranfer the Tag from the wrapping ContentControl
           // This is used for dispatching events and TouchEventHandler
@@ -147,7 +148,7 @@ namespace winrt::ReactNativeXaml {
 
         if (auto childFlyout = childContent.try_as<Controls::Primitives::FlyoutBase>()) {
           Primitives::FlyoutBase::SetAttachedFlyout(e, childFlyout);
-          wrappedChild.DataContext(e);
+          childFE.DataContext(e);
           if (auto button = e.try_as<Button>()) {
             return button.Flyout(childFlyout);
           }

--- a/package/windows/ReactNativeXaml/XamlViewManager.cpp
+++ b/package/windows/ReactNativeXaml/XamlViewManager.cpp
@@ -135,10 +135,10 @@ namespace winrt::ReactNativeXaml {
       child.try_as<NavigationView>()) { 
       // these are ContentControls too, but we shouldn't try to unwrap, so skip this 
     }
-    else if (auto childAsCC = child.try_as<Wrapper>()) {
-      if (auto childContent = childAsCC.Content()) {
+    else if (auto wrappedChild = child.try_as<Wrapper>()) {
+      if (auto childContent = wrappedChild.WrappedObject()) {
         childType = winrt::get_class_name(childContent);
-        auto tag = childAsCC.Tag();
+        auto tag = wrappedChild.Tag();
         if (auto depObj = childContent.try_as<DependencyObject>()) {
           // tranfer the Tag from the wrapping ContentControl
           // This is used for dispatching events and TouchEventHandler
@@ -147,7 +147,7 @@ namespace winrt::ReactNativeXaml {
 
         if (auto childFlyout = childContent.try_as<Controls::Primitives::FlyoutBase>()) {
           Primitives::FlyoutBase::SetAttachedFlyout(e, childFlyout);
-          childAsCC.DataContext(e);
+          wrappedChild.DataContext(e);
           if (auto button = e.try_as<Button>()) {
             return button.Flyout(childFlyout);
           }
@@ -218,8 +218,8 @@ namespace winrt::ReactNativeXaml {
       }
     }
 
-    if (auto contentCtrl = e.try_as<Wrapper>()) {
-      auto parentContent = contentCtrl.Content();
+    if (auto wrapper = e.try_as<Wrapper>()) {
+      auto parentContent = wrapper.WrappedObject();
       if (auto menuFlyout = parentContent.try_as<MenuFlyout>()) {
         if (auto mfi = child.try_as<MenuFlyoutItemBase>()) {
           return menuFlyout.Items().InsertAt(index, mfi);
@@ -230,6 +230,9 @@ namespace winrt::ReactNativeXaml {
           return flyout.Content(child);
         }
       }
+    }
+
+    if (auto contentCtrl = e.try_as<ContentControl>()) {
       if (index == 0 || contentCtrl.Content() == nullptr) {
         return contentCtrl.Content(child);
       }
@@ -267,7 +270,7 @@ namespace winrt::ReactNativeXaml {
     if (auto panel = e.try_as<Panel>()) {
       return panel.Children().Clear();
     }
-    else if (auto contentCtrl = e.try_as<Wrapper>()) {
+    else if (auto contentCtrl = e.try_as<ContentControl>()) {
       return contentCtrl.Content(nullptr);
     }
     else if (auto border = e.try_as<Border>()) {
@@ -287,7 +290,7 @@ namespace winrt::ReactNativeXaml {
       return itemsControl.Items().RemoveAt(static_cast<uint32_t>(index));
     }
     else if (index == 0) {
-      if (auto contentCtrl = e.try_as<Wrapper>()) {
+      if (auto contentCtrl = e.try_as<ContentControl>()) {
         return contentCtrl.Content(nullptr);
       }
       else if (auto border = e.try_as<Border>()) {


### PR DESCRIPTION
Some clean up, makes the delineation between ContentControl and the non-FrameworkElement wrapping container explicit.